### PR TITLE
Add distance in cm

### DIFF
--- a/adafruit_vl53l0x.py
+++ b/adafruit_vl53l0x.py
@@ -507,6 +507,13 @@ class VL53L0X:
             self._measurement_timing_budget_us = budget_us
 
     @property
+    def distance(self):
+        """Perform a single reading of the range for an object in front of
+        the sensor and return the distance in centimeters.
+        """
+        return self.range / 10
+
+    @property
     def range(self):
         """Perform a single reading of the range for an object in front of
         the sensor and return the distance in millimeters.


### PR DESCRIPTION
For #31.

This PR is non-breaking. A new `distance` property is added that returns value in units of `cm`. If we want to be breaking, can easily change this to replace the existing `range` property instead.

Tested on Itsy:
```python
Adafruit CircuitPython 7.0.0 on 2021-09-20; Adafruit ItsyBitsy M4 Express with samd51g19
>>> import board
>>> import adafruit_vl53l0x
>>> vl = adafruit_vl53l0x.VL53L0X(board.I2C())
>>> vl.distance
23.1
>>> vl.distance
18.7
>>> vl.distance
14.4
>>> vl.distance
11.4
>>> vl.distance
10.6
>>> 
```