### PR TITLE
*updated* Add .data_ready property to VL53L0X allowing end-users to predict if calls to .range will block

### DIFF
--- a/adafruit_vl53l0x.py
+++ b/adafruit_vl53l0x.py
@@ -553,8 +553,12 @@ class VL53L0X:
             ):
                 raise RuntimeError("Timeout waiting for VL53L0X!")
 
-    def read_range(self):
+    def read_range(self, max_ready_wait_us = None):
         """Return a range reading in millimeters.
+
+        If max_ready_wait_us is specified, and the sensor data is not ready
+        within that time, read_range will return -1, and you should call
+        read_range again in the future.
 
         Note: Avoid calling this directly. If you do single mode, you need
         to call `do_range_measurement` first. Or your program will stuck or
@@ -569,6 +573,8 @@ class VL53L0X:
                 and (time.monotonic() - start) >= self.io_timeout_s
             ):
                 raise RuntimeError("Timeout waiting for VL53L0X!")
+            if max_ready_wait_us != None and (time.monotonic() - start)*1_000_000 >= max_ready_wait_us:
+                return -1
         # assumptions: Linearity Corrective Gain is 1000 (default)
         # fractional ranging is not enabled
         range_mm = self._read_u16(_RESULT_RANGE_STATUS + 10)

--- a/adafruit_vl53l0x.py
+++ b/adafruit_vl53l0x.py
@@ -553,7 +553,7 @@ class VL53L0X:
             ):
                 raise RuntimeError("Timeout waiting for VL53L0X!")
 
-    def read_range(self, max_ready_wait_us=None):
+    def read_range(self, max_ready_wait_us = None):
         """Return a range reading in millimeters.
 
         If max_ready_wait_us is specified, and the sensor data is not ready
@@ -573,10 +573,7 @@ class VL53L0X:
                 and (time.monotonic() - start) >= self.io_timeout_s
             ):
                 raise RuntimeError("Timeout waiting for VL53L0X!")
-            if (
-                max_ready_wait_us is not None
-                and (time.monotonic() - start) * 1_000_000 >= max_ready_wait_us
-            ):
+            if max_ready_wait_us is not None and (time.monotonic() - start)*1_000_000 >= max_ready_wait_us:
                 return -1
         # assumptions: Linearity Corrective Gain is 1000 (default)
         # fractional ranging is not enabled

--- a/adafruit_vl53l0x.py
+++ b/adafruit_vl53l0x.py
@@ -573,7 +573,7 @@ class VL53L0X:
                 and (time.monotonic() - start) >= self.io_timeout_s
             ):
                 raise RuntimeError("Timeout waiting for VL53L0X!")
-            if max_ready_wait_us != None and (time.monotonic() - start)*1_000_000 >= max_ready_wait_us:
+            if max_ready_wait_us is not None and (time.monotonic() - start)*1_000_000 >= max_ready_wait_us:
                 return -1
         # assumptions: Linearity Corrective Gain is 1000 (default)
         # fractional ranging is not enabled

--- a/adafruit_vl53l0x.py
+++ b/adafruit_vl53l0x.py
@@ -553,7 +553,7 @@ class VL53L0X:
             ):
                 raise RuntimeError("Timeout waiting for VL53L0X!")
 
-    def read_range(self, max_ready_wait_us = None):
+    def read_range(self, max_ready_wait_us=None):
         """Return a range reading in millimeters.
 
         If max_ready_wait_us is specified, and the sensor data is not ready
@@ -573,7 +573,10 @@ class VL53L0X:
                 and (time.monotonic() - start) >= self.io_timeout_s
             ):
                 raise RuntimeError("Timeout waiting for VL53L0X!")
-            if max_ready_wait_us is not None and (time.monotonic() - start)*1_000_000 >= max_ready_wait_us:
+            if (
+                max_ready_wait_us is not None
+                and (time.monotonic() - start) * 1_000_000 >= max_ready_wait_us
+            ):
                 return -1
         # assumptions: Linearity Corrective Gain is 1000 (default)
         # fractional ranging is not enabled


### PR DESCRIPTION
**UPDATED PR DESCRIPTION**

Adds a .data_ready property to VL53L0X so end-users can avoid calling .range and getting blocked on the sensor's next reading.

Test results (Feather S2, 400khz I2C frequency, 200ms sensor:
- 200ms max block time on reading .range w/o change
- 1.8ms max block time on reading .range after waiting for .data_ready to be true

Notes:
- .data_ready adds approx 1ms performing the i2c check when called.
- at the default 100khz I2c rate, everything is approximately 20x slower, but still significantly faster than without the .data_ready check for larger measurement_timing_budgets. Definitely use 400khz if available.

ORIGINAL OUT OF DATE DESCRIPTION - IGNORE
```
Add a timeout to read_range to reduce block time when sensor data is not available

Previously in continuous mode the read_range function would wait until new sensor data was available to return. This meant that when the sensor measurement timing budget was large, the return would take similarly long and blocked program execution.

This change introduces max_ready_wait_us, an optional parameter that will cause read_range to return -1 after waiting this length of time. The calling function can then ignore the result, and call read_range again in the future to see if data is available then.

Test results (Feather S2, I2C rate 400khz, measurement_timing_budget 200ms, read_range called every 50ms):
- 145ms max block time without specifying max_ready_wait_us
- 2.2ms max block time when specifying max_ready_wait_us = 1

As this is an optional parameter where there was no parameter before, this change should be backwards compatible for all existing users of the driver.

This change should enable the use of this sensor for realtime applications where block time needs to be minimized like a balancing bot.  Related issue: https://github.com/adafruit/Adafruit_CircuitPython_VL53L0X/issues/34
```